### PR TITLE
Use Fabric's way to get mod resource files when running on Fabric

### DIFF
--- a/common/src/main/java/dev/qixils/crowdcontrol/common/Plugin.java
+++ b/common/src/main/java/dev/qixils/crowdcontrol/common/Plugin.java
@@ -29,11 +29,13 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.translation.GlobalTranslator;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 import javax.annotation.CheckReturnValue;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.util.*;
 import java.util.concurrent.Executor;
@@ -1327,5 +1329,16 @@ public interface Plugin<P, S> {
 		if (getPlayerManager().getLinkedAccounts(playerMapper().getUniqueId(player)).size() > 0)
 			return true;
 		return getSocketManagersFor(player).size() > 0;
+	}
+
+	/**
+	 * Gets one of the mod's resource files.
+	 *
+	 * @param asset filename
+	 * @return input stream if found
+	 */
+	@ApiStatus.Internal
+	default @Nullable InputStream getInputStream(@NotNull String asset) {
+		return getClass().getClassLoader().getResourceAsStream(asset);
 	}
 }

--- a/configurate-common/src/main/java/dev/qixils/crowdcontrol/plugin/configurate/ConfiguratePlugin.java
+++ b/configurate-common/src/main/java/dev/qixils/crowdcontrol/plugin/configurate/ConfiguratePlugin.java
@@ -4,6 +4,7 @@ import dev.qixils.crowdcontrol.CrowdControl;
 import dev.qixils.crowdcontrol.common.HideNames;
 import dev.qixils.crowdcontrol.common.LimitConfig;
 import dev.qixils.crowdcontrol.common.SoftLockConfig;
+import dev.qixils.crowdcontrol.exceptions.ExceptionUtil;
 import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.ConfigurateException;
@@ -75,7 +76,8 @@ public abstract class ConfiguratePlugin<P, S> extends dev.qixils.crowdcontrol.co
 		announce = config.node("announce").getBoolean(announce);
 		adminRequired = config.node("admin-required").getBoolean(adminRequired);
 		hideNames = HideNames.fromConfigCode(config.node("hide-names").getString(hideNames.getConfigCode()));
-		IP = config.node("ip").getString(IP);
+		IP = config.node("ip").getString(ExceptionUtil.validateNotNullElse(IP, ""));
+		if (IP.isEmpty()) IP = null;
 		port = config.node("port").getInt(port);
 		password = config.node("password").getString(password);
 		autoDetectIP = config.node("ip-detect").getBoolean(autoDetectIP);
@@ -164,9 +166,5 @@ public abstract class ConfiguratePlugin<P, S> extends dev.qixils.crowdcontrol.co
 		}
 
 		return HoconConfigurationLoader.builder().path(configPath).build();
-	}
-
-	public InputStream getInputStream(String asset) {
-		return getClass().getClassLoader().getResourceAsStream(asset);
 	}
 }

--- a/configurate-common/src/main/java/dev/qixils/crowdcontrol/plugin/configurate/ConfiguratePlugin.java
+++ b/configurate-common/src/main/java/dev/qixils/crowdcontrol/plugin/configurate/ConfiguratePlugin.java
@@ -152,7 +152,7 @@ public abstract class ConfiguratePlugin<P, S> extends dev.qixils.crowdcontrol.co
 
 		if (!Files.exists(configPath)) {
 			// read the default config
-			InputStream inputStream = getClass().getClassLoader().getResourceAsStream("assets/crowdcontrol/default.conf");
+			InputStream inputStream = getInputStream("assets/crowdcontrol/default.conf");
 			if (inputStream == null)
 				throw new IllegalStateException("Could not find default config file");
 			// copy the default config to the config path
@@ -164,5 +164,9 @@ public abstract class ConfiguratePlugin<P, S> extends dev.qixils.crowdcontrol.co
 		}
 
 		return HoconConfigurationLoader.builder().path(configPath).build();
+	}
+
+	public InputStream getInputStream(String asset) {
+		return getClass().getClassLoader().getResourceAsStream(asset);
 	}
 }

--- a/fabric/src/main/java/dev/qixils/crowdcontrol/plugin/fabric/FabricCrowdControlPlugin.java
+++ b/fabric/src/main/java/dev/qixils/crowdcontrol/plugin/fabric/FabricCrowdControlPlugin.java
@@ -24,6 +24,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.loader.api.FabricLoader;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.fabric.FabricServerAudiences;
 import net.kyori.adventure.pointer.Pointered;
@@ -43,6 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.Executor;
@@ -279,5 +282,20 @@ public class FabricCrowdControlPlugin extends ConfiguratePlugin<ServerPlayer, Co
 
 	public @NotNull net.minecraft.network.chat.Component toNative(ComponentLike text, @NotNull Pointered viewer) {
 		return adventure().toNative(toAdventure(text, viewer));
+	}
+
+	@Override
+	public InputStream getInputStream(String asset) {
+		Optional<Path> path = FabricLoader.getInstance().getModContainer("crowdcontrol").orElseThrow().findPath(asset);
+		if (path.isPresent()) {
+			try {
+				return path.get().getFileSystem()
+					.provider()
+					.newInputStream(path.get());
+			} catch (IOException e) {
+				SLF4JLogger.warn(String.format("Encountered exception while retrieving asset {0}! " + e.getMessage(), asset));
+			}
+		}
+		return null;
 	}
 }

--- a/fabric/src/main/java/dev/qixils/crowdcontrol/plugin/fabric/FabricCrowdControlPlugin.java
+++ b/fabric/src/main/java/dev/qixils/crowdcontrol/plugin/fabric/FabricCrowdControlPlugin.java
@@ -46,6 +46,7 @@ import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.Executor;
@@ -285,17 +286,19 @@ public class FabricCrowdControlPlugin extends ConfiguratePlugin<ServerPlayer, Co
 	}
 
 	@Override
-	public InputStream getInputStream(String asset) {
-		Optional<Path> path = FabricLoader.getInstance().getModContainer("crowdcontrol").orElseThrow().findPath(asset);
-		if (path.isPresent()) {
-			try {
-				return path.get().getFileSystem()
-					.provider()
-					.newInputStream(path.get());
-			} catch (IOException e) {
-				SLF4JLogger.warn(String.format("Encountered exception while retrieving asset {0}! " + e.getMessage(), asset));
-			}
-		}
-		return null;
+	public InputStream getInputStream(@NotNull String asset) {
+		Optional<Path> path = FabricLoader.getInstance()
+			.getModContainer("crowdcontrol")
+			.flatMap(container -> container.findPath(asset));
+
+        if (path.isEmpty())
+            return null;
+
+        try {
+			return Files.newInputStream(path.get());
+        } catch (IOException e) {
+            SLF4JLogger.warn(String.format("Encountered exception while retrieving asset %s", asset), e);
+			return null;
+        }
 	}
 }


### PR DESCRIPTION
Hey! Had to recently fix the same thing in a different mod, thought i'd PR the same here.
Fabric shares a classloader across multiple mods, which can lead to issues when using `getClass().getClassLoader().getResourceAsStream()`. While this currently shouldn't cause conflicts - other mods won't ship their own `assets/crowdcontrol/default.conf`, this just ensures future-proofing.